### PR TITLE
Fix the type declarations for slots HISTID and REXID of class CONNECT…

### DIFF
--- a/trivial-swank.lisp
+++ b/trivial-swank.lisp
@@ -60,11 +60,11 @@
    ;history
    (histid  :accessor histid
             :initform nil
-            :type fixnum
+            :type (or null fixnum)
             :documentation "history-tracking id")
    (rexid   :accessor rexid
             :initform nil
-            :type fixnum
+            :type (or null fixnum)
             :documentation "last-processed rex id")
    
    (socket :accessor socket


### PR DESCRIPTION
…ION.

Both slots can be NIL, so the old FIXNUM type declaration was wrong.